### PR TITLE
Added Swagger-UI tab to editor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "name": "Nick O'Leary"
   },
   "dependencies": {
-    "swagger-ui": "^2.1.0"
+    "swagger-ui": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,25 @@
 {
-    "name": "node-red-node-swagger",
-    "version": "0.0.1",
-    "description": "A set of tools for generating Swagger api documentation based on the HTTP nodes deployed in a flow",
-    "license": "Apache",
-    "repository"   : {
-        "type":"git",
-        "url":"https://github.com/node-red/node-red-node-swagger.git"
-    },
-    "keywords": [
-        "node-red",
-        "swagger"
-    ],
-    "node-red": {
-        "nodes": {
-            "swagger": "swagger/swagger.js"
-        }
-    },
-    "author": {
-        "name": "Nick O'Leary"
+  "name": "node-red-node-swagger",
+  "version": "0.0.1",
+  "description": "A set of tools for generating Swagger API documentation based on the HTTP nodes deployed in a flow",
+  "license": "Apache",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/node-red/node-red-node-swagger.git"
+  },
+  "keywords": [
+    "node-red",
+    "swagger"
+  ],
+  "node-red": {
+    "nodes": {
+      "swagger": "swagger/swagger.js"
     }
+  },
+  "author": {
+    "name": "Nick O'Leary"
+  },
+  "dependencies": {
+    "swagger-ui": "^2.1.0"
+  }
 }

--- a/swagger/swagger-ui/swagger-ui.html
+++ b/swagger/swagger-ui/swagger-ui.html
@@ -17,8 +17,7 @@
   <script src='reqs/lib/highlight.7.3.pack.js' type='text/javascript'></script>
   <script src='reqs/lib/marked.js' type='text/javascript'></script>
   <script type="text/javascript">
-    //var url = "http://petstore.swagger.io/v2/swagger.json";
-    var url = "../../http-api/swagger.json";
+    var url = parent.swaggerDocUrl;
     window.swaggerUi = new SwaggerUi({
       url: url,
       dom_id: "swagger-ui-container",

--- a/swagger/swagger-ui/swagger-ui.html
+++ b/swagger/swagger-ui/swagger-ui.html
@@ -6,7 +6,6 @@
   <link href='reqs/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='reqs/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
   <link href='reqs/css/screen.css' media='print' rel='stylesheet' type='text/css'/>
-  <script type="text/javascript" src="reqs/lib/shred.bundle.js"></script>
   <script src='reqs/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
   <script src='reqs/lib/jquery.slideto.min.js' type='text/javascript'></script>
   <script src='reqs/lib/jquery.wiggle.min.js' type='text/javascript'></script>
@@ -14,7 +13,6 @@
   <script src='reqs/lib/handlebars-2.0.0.js' type='text/javascript'></script>
   <script src='reqs/lib/underscore-min.js' type='text/javascript'></script>
   <script src='reqs/lib/backbone-min.js' type='text/javascript'></script>
-  <script src='reqs/lib/swagger-client.js' type='text/javascript'></script>
   <script src='reqs/swagger-ui.js' type='text/javascript'></script>
   <script src='reqs/lib/highlight.7.3.pack.js' type='text/javascript'></script>
   <script src='reqs/lib/marked.js' type='text/javascript'></script>
@@ -25,13 +23,12 @@
       url: url,
       dom_id: "swagger-ui-container",
       onComplete: function(data) {
-        log('SwaggerUI loaded!');
+		console.log('SwaggerUI loaded!');
       },
       onFailure: function(data) {
-          log("Unable to Load SwaggerUI");
+		console.log("Unable to Load SwaggerUI");
       },
     });
-    //window.swaggerUi.load();
   </script>
 </head>
 

--- a/swagger/swagger-ui/swagger-ui.html
+++ b/swagger/swagger-ui/swagger-ui.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+  <title>Swagger UI</title>
+  <link href='reqs/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='reqs/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='reqs/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='reqs/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='reqs/css/screen.css' media='print' rel='stylesheet' type='text/css'/>
+  <script type="text/javascript" src="reqs/lib/shred.bundle.js"></script>
+  <script src='reqs/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+  <script src='reqs/lib/jquery.slideto.min.js' type='text/javascript'></script>
+  <script src='reqs/lib/jquery.wiggle.min.js' type='text/javascript'></script>
+  <script src='reqs/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+  <script src='reqs/lib/handlebars-2.0.0.js' type='text/javascript'></script>
+  <script src='reqs/lib/underscore-min.js' type='text/javascript'></script>
+  <script src='reqs/lib/backbone-min.js' type='text/javascript'></script>
+  <script src='reqs/lib/swagger-client.js' type='text/javascript'></script>
+  <script src='reqs/swagger-ui.js' type='text/javascript'></script>
+  <script src='reqs/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+  <script src='reqs/lib/marked.js' type='text/javascript'></script>
+  <script type="text/javascript">
+    //var url = "http://petstore.swagger.io/v2/swagger.json";
+    var url = "../../http-api/swagger.json";
+    window.swaggerUi = new SwaggerUi({
+      url: url,
+      dom_id: "swagger-ui-container",
+      onComplete: function(data) {
+        log('SwaggerUI loaded!');
+      },
+      onFailure: function(data) {
+          log("Unable to Load SwaggerUI");
+      },
+    });
+    //window.swaggerUi.load();
+  </script>
+</head>
+
+<body class="swagger-section">
+<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+</body>
+</html>

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -112,6 +112,44 @@
         label: function() {
             return this.summary || "swagger doc";
         },
+        onpaletteadd: function() {
+            //setup swagger-ui
+            var swaggerUi;
+            var refreshInfoHeight = 75;
+            var content = $("<div/>",{
+                id:"tab-swagger-ui", style:"position: relative; padding: 0px 4px; height: 100%; overflow: hidden"
+            });
+            var refreshInfo = $("<div/>", {
+                style:"height: "+ refreshInfoHeight + "px; margin: 5px; text-align: center"
+            });
+            $("<p/>", {
+                text: "Please click refresh after making changes to any HTTP nodes."
+            }).appendTo(refreshInfo);
+            $("<div/>", {
+                style: 'margin: auto; height: 20px; width: 100px; border-radius: 25px; border: 2px solid #8AC007; cursor: pointer',
+                html: '<i class="fa fa-refresh" /> Refresh',
+                click: function(){
+                    swaggerUi.load();
+                }
+            }).appendTo(refreshInfo);
+            refreshInfo.appendTo(content);
+            $("<hr/>").appendTo(content);
+            var swaggerFrame = $("<iframe/>", {
+                id:"swagger-ui-frame", 
+                style:"margin: 0px 5px; padding: 0; border: none; width: 100%; height: " + (content.height() - refreshInfoHeight - 45) + "px", 
+                src:"http://localhost:1880/swagger-ui/swagger-ui.html"
+            }).appendTo(content);
+            RED.sidebar.addTab("swagger-ui", content);
+            console.log('here');
+            
+            setTimeout(function(){
+                swaggerUi = document.getElementById('swagger-ui-frame').contentWindow.swaggerUi;
+                window.addEventListener('resize', function(event){
+                    swaggerFrame.css('height', content.height() - refreshInfoHeight - 45);
+                });
+                swaggerUi.load();
+            }, 1000);
+        },
         oneditprepare: function() {
             $('.popover-right').popover({
                 placement:"right",

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -80,6 +80,7 @@
 </script>
 
 <script type="text/javascript">
+var swaggerDocUrl;
 (function() {
     RED.nodes.registerType('swagger-doc', {
         category: 'config',
@@ -134,10 +135,11 @@
             }).appendTo(refreshInfo);
             refreshInfo.appendTo(content);
             $("<hr/>").appendTo(content);
-            var swaggerFrame = $("<iframe/>", {
+			swaggerDocUrl = window.location.protocol + "//" + window.location.hostname + ":" + window.location.port + RED.settings.httpNodeRoot + 'http-api/swagger.json';
+			var swaggerFrame = $("<iframe/>", {
                 id:"swagger-ui-frame", 
                 style:"margin: 0px 5px; padding: 0; border: none; width: 100%", 
-                src:"http://localhost:1880/swagger-ui/swagger-ui.html"
+                src: "swagger-ui/swagger-ui.html"
             }).appendTo(content);
             RED.sidebar.addTab("swagger-ui", content);
             

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -136,7 +136,7 @@
             $("<hr/>").appendTo(content);
             var swaggerFrame = $("<iframe/>", {
                 id:"swagger-ui-frame", 
-                style:"margin: 0px 5px; padding: 0; border: none; width: 100%; height: " + (content.height() - refreshInfoHeight - 45) + "px", 
+                style:"margin: 0px 5px; padding: 0; border: none; width: 100%", 
                 src:"http://localhost:1880/swagger-ui/swagger-ui.html"
             }).appendTo(content);
             RED.sidebar.addTab("swagger-ui", content);
@@ -147,6 +147,7 @@
                 window.addEventListener('resize', function(event){
                     swaggerFrame.css('height', content.height() - refreshInfoHeight - 45);
                 });
+				swaggerFrame.css('height', content.height() - refreshInfoHeight - 45);
                 swaggerUi.load();
             }, 1000);
         },

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -140,16 +140,15 @@
                 src:"http://localhost:1880/swagger-ui/swagger-ui.html"
             }).appendTo(content);
             RED.sidebar.addTab("swagger-ui", content);
-            console.log('here');
             
-            setTimeout(function(){
+            swaggerFrame.load(function(){
                 swaggerUi = document.getElementById('swagger-ui-frame').contentWindow.swaggerUi;
                 window.addEventListener('resize', function(event){
                     swaggerFrame.css('height', content.height() - refreshInfoHeight - 45);
                 });
 				swaggerFrame.css('height', content.height() - refreshInfoHeight - 45);
                 swaggerUi.load();
-            }, 1000);
+            });
         },
         oneditprepare: function() {
             $('.popover-right').popover({

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -127,4 +127,13 @@ module.exports = function(RED) {
         this.deprecated = n.deprecated;
     }
     RED.nodes.registerType("swagger-doc",SwaggerDoc);
+    
+    RED.httpAdmin.get('/swagger-ui/reqs/*', function(req, res){
+        var filename = path.join(__dirname , 'node_modules/swagger-ui/dist', req.params[0]);
+        res.sendfile(filename);
+    });
+    RED.httpAdmin.get('/swagger-ui/*', function(req, res){
+        var filename = path.join(__dirname , 'swagger-ui', req.params[0]);
+        res.sendfile(filename);
+    });
 }

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -129,7 +129,7 @@ module.exports = function(RED) {
     RED.nodes.registerType("swagger-doc",SwaggerDoc);
     
     RED.httpAdmin.get('/swagger-ui/reqs/*', function(req, res){
-        var filename = path.join(__dirname , 'node_modules/swagger-ui/dist', req.params[0]);
+        var filename = path.join(__dirname , '../node_modules/swagger-ui/dist', req.params[0]);
         res.sendfile(filename);
     });
     RED.httpAdmin.get('/swagger-ui/*', function(req, res){


### PR DESCRIPTION
Incorporates Swagger-UI into the editor, creating a new tab where the user can view and test the swagger doc that is being dynamically generated by the plugin.

For now, the user will have to manually refresh the swagger-ui to get the newly generated swagger doc after making changes and deploying. This will be changed once there is an api to tap into node-red's events.