### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "Cody Walker <cody@cody-walker.com>"
     ],
     "dependencies": {
-        "swagger-ui": "2.1.4",
-        "i18next-client": "1.10.3"
+        "swagger-ui": "2.2.6",
+        "i18next-client": "1.11.4"
     }
 }


### PR DESCRIPTION
The version of swagger-ui used by node-red-node-swagger at the moment is affected by 3 vulnerabilities:
https://nodesecurity.io/advisories/123
https://nodesecurity.io/advisories/126
https://nodesecurity.io/advisories/131

```
$ nsp check --output summary
(+) 3 vulnerabilities found
 Name         Installed   Patched   Path                                             More Info
 swagger-ui   2.1.4       >=2.2.1   node-red-node-swagger@0.1.8 > swagger-ui@2.1.4   https://nodesecurity.io/advisories/126
 swagger-ui   2.1.4       >=2.1.5   node-red-node-swagger@0.1.8 > swagger-ui@2.1.4   https://nodesecurity.io/advisories/123
 swagger-ui   2.1.4       >=2.1.5   node-red-node-swagger@0.1.8 > swagger-ui@2.1.4   https://nodesecurity.io/advisories/131
```

Upgrading the dependencies fixes the issue.