### PR TITLE
Enable multiple node types with swagger doc. Depends on optional NR_S…

### DIFF
--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-
 module.exports = function(RED) {
     "use strict";
-
+	
+	var supportedEndPoints;
+	if(RED.settings.swagger && RED.settings.swagger.endPoints){
+		supportedEndPoints = RED.settings.swagger.endPoints; 
+	} else {
+		supportedEndPoints = ["http in"];
+	}
+	
     var path = require("path");
     RED.httpNode.get("/http-api/swagger.json",function(req,res) {
         var resp;
@@ -48,7 +54,8 @@ module.exports = function(RED) {
         }
         resp.paths = {};
         RED.nodes.eachNode(function(node) {
-            if (node && node.type === "http in") {
+            //if (node && node.type === "http in") {
+			if (node && supportedEndPoints.indexOf(node.type) >= 0) {				
                 if(checkWiresForHttpResponse(node)){
                     var swagger = RED.nodes.getNode(node.swaggerDoc);
 

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -16,7 +16,7 @@
 module.exports = function(RED) {
     "use strict";
 	
-	var supportedEndPoints;
+	var supportedEndPoints; //List of node types supporting sagger
 	if(RED.settings.swagger && RED.settings.swagger.endPoints){
 		supportedEndPoints = RED.settings.swagger.endPoints; 
 	} else {

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -54,7 +54,6 @@ module.exports = function(RED) {
         }
         resp.paths = {};
         RED.nodes.eachNode(function(node) {
-            //if (node && node.type === "http in") {
 			if (node && supportedEndPoints.indexOf(node.type) >= 0) {				
                 if(checkWiresForHttpResponse(node)){
                     var swagger = RED.nodes.getNode(node.swaggerDoc);


### PR DESCRIPTION
Enable multiple node types with swagger doc. Depends on optional NR_Settings configuration: swagger.endPoints - array with supported node types.

`Example: 	swagger: {
		"endPoints": ["http in", "stream in"],
                ....`